### PR TITLE
Question Pinning Feature & src/topics/data.js Sanity Check

### DIFF
--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const validator = require('validator');
+const assert = require('assert');
 
 const db = require('../database');
 const categories = require('../categories');
@@ -16,7 +17,15 @@ const intFields = [
 ];
 
 module.exports = function (Topics) {
+    /**
+     * Gets topics by fields
+     * @param {Promise<object>} tids
+     * @param {Promise<object>} fields
+    * @returns {Promise<object>}
+    */
     Topics.getTopicsFields = async function (tids, fields) {
+        // Assert function parameter types in the body
+        assert(typeof fields === 'object', 'Expected fields to be an object');
         if (!Array.isArray(tids) || !tids.length) {
             return [];
         }
@@ -34,51 +43,153 @@ module.exports = function (Topics) {
             keys: keys,
         });
         result.topics.forEach(topic => modifyTopic(topic, fields));
-        return result.topics;
+        const topicsResult = result.topics;
+        // Assert function return types in the body
+        assert(typeof topicsResult === 'object', 'Expected result to be an object');
+        return topicsResult;
     };
 
+    /**
+     * Gets topics field
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+     * @param {Promise<string>} field
+    * @returns {Promise<number> || Promise<string> || Promise<boolean>}
+    */
     Topics.getTopicField = async function (tid, field) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
+        assert(typeof field === 'string', 'Expected field to be a string');
         const topic = await Topics.getTopicFields(tid, [field]);
-        return topic ? topic[field] : null;
+        const result = topic ? topic[field] : null;
+        // Assert function return types in the body
+        assert(typeof result === 'number' || typeof result === 'string' || typeof result === 'boolean', 'Expected result to be a number or string or boolean');
+        return result;
     };
 
+    /**
+     * Gets topics fields
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+     * @param {Promise<object>} fields
+    * @returns {Promise<object>}
+    */
     Topics.getTopicFields = async function (tid, fields) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
+        assert(typeof fields === 'object', 'Expected fields to be an object');
         const topics = await Topics.getTopicsFields([tid], fields);
-        return topics ? topics[0] : null;
+        const result = topics ? topics[0] : null;
+        // Assert function return types in the body
+        assert(typeof result === 'object', 'Expected result to be an object');
+        return result;
     };
 
+    /**
+     * Gets data for the topic
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+    * @returns {Promise<object>}
+    */
     Topics.getTopicData = async function (tid) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
         const topics = await Topics.getTopicsFields([tid], []);
-        return topics && topics.length ? topics[0] : null;
+        const result = topics && topics.length ? topics[0] : null;
+        // Assert function return types in the body
+        assert(typeof result === 'object', 'Expected result to be an object');
+        return result;
     };
 
+    /**
+     * Gets all data for the topics
+     * @param {Promise<object>} tids
+    * @returns {Promise<object>}
+    */
     Topics.getTopicsData = async function (tids) {
-        return await Topics.getTopicsFields(tids, []);
+        // Assert function parameter types in the body
+        assert(typeof tids === 'object', 'Expected tids to be an object');
+        const result = await Topics.getTopicsFields(tids, []);
+        // Assert function return types in the body
+        assert(typeof result === 'object', 'Expected result to be an object');
+        return result;
     };
 
+    /**
+     * Gets category data
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+    * @returns {Promise<object>}
+    */
     Topics.getCategoryData = async function (tid) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
         const cid = await Topics.getTopicField(tid, 'cid');
-        return await categories.getCategoryData(cid);
+        const result = await categories.getCategoryData(cid);
+        // Assert function return types in the body
+        assert(typeof result === 'object', 'Expected result to be an object');
+        return result;
     };
 
+    /**
+     * Sets a field for a topic
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+     * @param {Promise<string>} field
+     * @param {Promise<number>} value
+    * @returns {Promise<void>}
+    */
     Topics.setTopicField = async function (tid, field, value) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
+        assert(typeof field === 'string', 'Expected field to be a string');
+        assert(typeof value === 'number', 'Expected value to be a number');
         await db.setObjectField(`topic:${tid}`, field, value);
     };
 
+    /**
+     * Sets all fields for the topic
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+     * @param {Promise<object>} data
+    * @returns {Promise<void>}
+    */
     Topics.setTopicFields = async function (tid, data) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
+        assert(typeof data === 'object', 'Expected data to be an object');
         await db.setObject(`topic:${tid}`, data);
     };
 
+    /**
+     * Delete a fields for a topic
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+     * @param {Promise<string>} field
+    * @returns {Promise<void>}
+    */
     Topics.deleteTopicField = async function (tid, field) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
+        assert(typeof field === 'string', 'Expected field to be a string');
         await db.deleteObjectField(`topic:${tid}`, field);
     };
 
+    /**
+     * Delete all fields for a topic
+     * @param {Promise<number> || Promise<string> || Promise<undefined>} tid
+     * @param {Promise<string>} field
+    * @returns {Promise<void>}
+    */
     Topics.deleteTopicFields = async function (tid, fields) {
+        // Assert function parameter types in the body
+        assert(typeof tid === 'number' || typeof tid === 'string' || typeof tid === 'undefined', 'Expected tid to be a number or string or undefined');
+        assert(typeof fields === 'object', 'Expected fields to be an object');
         await db.deleteObjectFields(`topic:${tid}`, fields);
     };
 };
 
+/**
+ * Escapes the title in the topicData object
+ * @param {Promise<object>} topicData
+ * @returns {Promise<void>}
+*/
 function escapeTitle(topicData) {
+    // Assert function parameter types in the body
+    assert(typeof topicData === 'object', 'Expected topicData to be an object');
     if (topicData) {
         if (topicData.title) {
             topicData.title = translator.escape(validator.escape(topicData.title));
@@ -89,7 +200,16 @@ function escapeTitle(topicData) {
     }
 }
 
+/**
+ * Modifies a topic object with the provided fields
+ * @param {Promise<object>} topic
+ * @param {Promise<object>} fields
+ * @returns {Promise<void>}
+*/
 function modifyTopic(topic, fields) {
+    // Assert function parameter types in the body
+    assert(typeof topic === 'object', 'Expected topic to be an object');
+    assert(typeof fields === 'object', 'Expected fields to be an object');
     if (!topic) {
         return;
     }

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -150,6 +150,7 @@ module.exports = function (Topics) {
     };
 
     async function togglePin(tid, uid, pin) {
+        console.log("HIHIH")
         const topicData = await Topics.getTopicData(tid);
         if (!topicData) {
             throw new Error('[[error:no-topic]]');
@@ -159,7 +160,7 @@ module.exports = function (Topics) {
             throw new Error('[[error:cant-pin-scheduled]]');
         }
 
-        if (uid !== 'system' && !await privileges.topics.isAdminOrMod(tid, uid)) {
+        if (uid !== 'system' && !await privileges.topics.isAdminOrMod(tid, uid) && !await user.isInstructor(uid)) {
             throw new Error('[[error:no-privileges]]');
         }
 

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -150,7 +150,6 @@ module.exports = function (Topics) {
     };
 
     async function togglePin(tid, uid, pin) {
-        console.log("HIHIH")
         const topicData = await Topics.getTopicData(tid);
         if (!topicData) {
             throw new Error('[[error:no-topic]]');

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -15,12 +15,15 @@
             font-size: 24px;
             color: white;
         }
+        .pinned {
+            background-color: #cefad0;
+        }
     </style>
 </head>
 
 <ul component="category" class="topic-list" itemscope itemtype="http://www.schema.org/ItemList" data-nextstart="{nextStart}" data-set="{set}">
     {{{each topics}}}
-    <li component="category/topic" class="row clearfix category-item {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl -->>
+    <li component="category/topic" class="row clearfix category-item {function.generateTopicClass} {{if topics.pinned}}pinned{{/if}}" <!-- IMPORT partials/data/category.tpl -->>
         <link itemprop="url" content="{config.relative_path}/topic/{../slug}" />
         <meta itemprop="name" content="{function.stripTags, ../title}" />
         <meta itemprop="itemListOrder" content="descending" />


### PR DESCRIPTION
What: Extended the pin/unpic topic privilege to instructors. When instructors pin a topic, the topic teaser is highlighted

Why: instructors should be able to highlight important topics by pinning them

How:
Backend: Modified functions related to pin/unpin topics to return true for instructors.
Frontend: Modified .tpl files that corresponded with showing the pinned topics.

Additional:
- Added sanity-checks for file src/topics/data.js
- Did not translate to Typescript, but need to make JS file type safe
- Added following sanity-checks:
- 
1. Document the type signature in code comments
2. Assert function parameter types in the body
3. Assert function return types in the body or write unit tests that execute and validate that the function returns the expected type.

- Ensured npm run lint and npm run test passed.

Resolves #10 
Resolves #37 